### PR TITLE
feat: exponentially increase the polling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ finding credentials (Environment, INI File, EC2 Metadata Service), which is docu
 [docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Using_Profiles_with_the_SDK).
 
 If you use the `--wait` option, the command will not exit until the invalidation is complete. It does
-this by polling `GetInvalidation` every 5 seconds.
+this by polling `GetInvalidation` after 1000ms * 2^iterationCycle (e.g. it increases the timeout between polls exponentially).
 
 This tool needs permission for `cloudfront:CreateInvalidation` and `cloudfront:GetInvalidation`.
 

--- a/index.js
+++ b/index.js
@@ -96,9 +96,11 @@
                         if (res.Invalidation.Status === "Completed") {
                             return callback();
                         } else {
+                            var nextTry = 1000 * Math.pow(2, i++);
+                            log('Invalidation not done yet, next try in ' + nextTry + 'ms.')
                             setTimeout(function () {
                                 iteration();
-                            }, 1000 * Math.pow(2, i++));
+                            }, nextTry);
                         }
                         
                     });

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@
             
             var invalidationId = res.Invalidation.Id;
             if (options.wait) {
-                
+                var i = 0;
                 var iteration = function () {
                     cloudfront.getInvalidation({
                         DistributionId: dist,
@@ -98,7 +98,7 @@
                         } else {
                             setTimeout(function () {
                                 iteration();
-                            }, 1000);
+                            }, 1000 * Math.pow(2, i++));
                         }
                         
                     });


### PR DESCRIPTION
Currently CF is polled every second for whether the invalidation has completed. I changed this to a more organic polling cycle: 1000ms, 2000ms, 4000ms, etc.
